### PR TITLE
add link to zephyr device tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ In addition to the LoRa module, there are 5 RGB LEDs on the side, a qwiic/Stemma
 Feel free to submit a PR adding on to this list with your project that runs on the badge.
 
 - [Initial Meshtastic firmware](https://github.com/badgeteam/bornhack2025-meshtastic) ([Flasher tool](https://github.com/badgeteam/bornhack2025-flasher))
+- [Zephyr device tree](https://cyberchaos.dev/kloenk/bornhack-2025-badge) (no actually firmware, just support files)
 - _project name and link to more info_
 
 


### PR DESCRIPTION
Add a link to zephyr device trees that can be used to write firmware with zephyr[0] on the badge

This is not an actual project running on the badge. But only some support files to make using zephyr easier. Tested with some simple hello world samples 

[0]: https://zephyrproject.org/